### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/lib/fluent/plugin/out_devo.rb
+++ b/lib/fluent/plugin/out_devo.rb
@@ -123,7 +123,7 @@ module Fluent::Plugin
     def process(tag, es)
       es.each do |time, record|
         record.each_pair do |_, v|
-          v.dup.force_encoding('utf-8') if v.is_a?(String)
+          v = v.dup.force_encoding('utf-8') if v.is_a?(String)
         end
 
         # Check if severity has been provided in record otherwise use INFO

--- a/lib/fluent/plugin/out_devo.rb
+++ b/lib/fluent/plugin/out_devo.rb
@@ -123,7 +123,7 @@ module Fluent::Plugin
     def process(tag, es)
       es.each do |time, record|
         record.each_pair do |_, v|
-          v.force_encoding('utf-8') if v.is_a?(String)
+          v.dup.force_encoding('utf-8') if v.is_a?(String)
         end
 
         # Check if severity has been provided in record otherwise use INFO

--- a/lib/syslog_tls/version.rb
+++ b/lib/syslog_tls/version.rb
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 module SyslogTls
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
Fix the plugin to use a duplicate object when forcing encoding of string since some strings may be locked and not able to be modified.