### PR TITLE
Windows compatibility for socket config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 1.2.0
+
+· Fix windows socket compatibility
+
 #### 1.1.0
 
 · Fix the plugin to use a duplicate object when forcing encoding of string since some strings may be locked and not able to be modified.

--- a/lib/syslog_tls/ssl_transport.rb
+++ b/lib/syslog_tls/ssl_transport.rb
@@ -16,6 +16,7 @@
 
 require 'socket'
 require 'openssl'
+require 'rbconfig'
 
 module SyslogTls
   # Supports SSL connection to remote host
@@ -70,8 +71,10 @@ module SyslogTls
       begin
         sock_addr = Socket.sockaddr_in(port, address)
         tcp = Socket.new(family, sock_type, 0)
-        tcp.setsockopt(Socket::SOL_SOCKET, Socket::Constants::SO_REUSEADDR, true)
-        tcp.setsockopt(Socket::SOL_SOCKET, Socket::Constants::SO_REUSEPORT, true)
+        tcp.setsockopt(Socket::SOL_SOCKET, Socket::Constants::SO_REUSEADDR, false)
+        if !RbConfig::CONFIG['host_os'].match?(/mswin|mingw|cygwin/)
+          tcp.setsockopt(Socket::SOL_SOCKET, Socket::Constants::SO_REUSEPORT, false)
+        end
         tcp.connect_nonblock(sock_addr)
       rescue Errno::EINPROGRESS
         select_with_timeout(tcp, :connect_write)

--- a/lib/syslog_tls/version.rb
+++ b/lib/syslog_tls/version.rb
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 module SyslogTls
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
Edit the following files:
### lib/syslog_tls/ssl_transport.rb
- Change logic to check if running in windows environment
- If running in windows environment disable nix specific socket configuration

### lib/syslog_tls/version.rb
- Bump version

### CHANGELOG.md
- Bump version and add description of changes